### PR TITLE
Type infer for constant values in context

### DIFF
--- a/examples/jit.rs
+++ b/examples/jit.rs
@@ -9,8 +9,12 @@ fn main() {
     let mut builder = context.create_builder();
 
     let function_type = llvm::function_type(
-        context.int64_type(),
-        vec![context.int64_type(), context.int64_type(), context.int64_type()],
+        i64::get_type_in_context(&context),
+        vec![
+            i64::get_type_in_context(&context),
+            i64::get_type_in_context(&context),
+            i64::get_type_in_context(&context)
+        ],
         false);
     let mut func = module.add_function(function_type, "fname");
     let bb = context.append_basic_block(&mut func, "fname");
@@ -20,6 +24,8 @@ fn main() {
     let x = func.get_param(0).unwrap();
     let y = func.get_param(1).unwrap();
     let z = func.get_param(2).unwrap();
+
+    let b = context.cons(20.0f64);
 
     let sum = builder.build_add(x, y, "sum");
     let sum = builder.build_add(sum, z, "sum");
@@ -31,7 +37,7 @@ fn main() {
     llvm::initialize_native_target();
     llvm::initialize_native_asm_printer();
 
-    let ee = llvm::ExecutionEngine::create_for_module(module).unwrap();
+    let ee = llvm::ExecutionEngine::create_for_module(&module).unwrap();
     let addr = ee.get_function_address("fname").unwrap();
 
     unsafe {

--- a/examples/jit.rs
+++ b/examples/jit.rs
@@ -25,11 +25,12 @@ fn main() {
     let y = func.get_param(1).unwrap();
     let z = func.get_param(2).unwrap();
 
-    let b = context.cons(20.0f64);
+    let b = context.cons(20i8);
 
-    let sum = builder.build_add(x, y, "sum");
-    let sum = builder.build_add(sum, z, "sum");
-    builder.build_ret(sum);
+    let s1 = builder.build_add(x, b, "s1");
+    let s2 = builder.build_add(y, s1, "s2");
+    let s3 = builder.build_add(z, s2, "s3");
+    builder.build_ret(s3);
 
     module.dump();
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -7,6 +7,7 @@ use super::*;
 pub struct Builder {
     pub ptr: LLVMBuilderRef
 }
+impl_llvm_ref!(Builder, LLVMBuilderRef);
 
 impl Builder {
     pub fn position_at_end(&mut self, basic_block: LLVMBasicBlockRef) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,6 +10,7 @@ use value::IntoConstValue;
 pub struct Context {
     pub ptr: LLVMContextRef
 }
+impl_llvm_ref!(Context, LLVMContextRef);
 
 impl Context {
     pub fn new() -> Self {

--- a/src/context.rs
+++ b/src/context.rs
@@ -61,5 +61,3 @@ impl Drop for Context {
         }
     }
 }
-
-

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,7 @@ use llvm_sys::core as llvm;
 
 use super::*;
 
+use value::IntoConstValue;
 
 // LLVM Wrappers
 
@@ -39,46 +40,17 @@ impl Context {
         }
     }
 
-    pub fn int64_type(&self) -> LLVMTypeRef {
-        unsafe {
-            llvm::LLVMInt64TypeInContext(self.ptr)
-        }
-    }
-
-    pub fn int32_type(&self) -> LLVMTypeRef {
-        unsafe {
-            llvm::LLVMInt32TypeInContext(self.ptr)
-        }
-    }
-
-    pub fn int16_type(&self) -> LLVMTypeRef {
-        unsafe {
-            llvm::LLVMInt16TypeInContext(self.ptr)
-        }
-    }
-
-    pub fn int8_type(&self) -> LLVMTypeRef {
-        unsafe {
-            llvm::LLVMInt8TypeInContext(self.ptr)
-        }
-    }
-
-    pub fn int1_type(&self) -> LLVMTypeRef {
-        unsafe {
-            llvm::LLVMInt1TypeInContext(self.ptr)
-        }
-    }
-
-    pub fn const_bool(&self, val: bool) -> LLVMValueRef {
-        let ty = self.int1_type();
-        const_int(ty, val as u64, false)
-    }
-
     pub fn append_basic_block(&self, func: &mut Function, name: &str) -> LLVMBasicBlockRef {
         let c_name = CString::new(name).unwrap();
         unsafe {
             llvm::LLVMAppendBasicBlockInContext(self.ptr, func.ptr, c_name.as_ptr())
         }
+    }
+
+    /// Creates a constant in this context
+    /// The value must implement the trait `IntoValue`
+    pub fn cons<T: IntoConstValue>(&self, val: T) -> LLVMValueRef {
+        val.gen_const(self)
     }
 }
 

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -5,6 +5,7 @@ use std::mem;
 pub struct ExecutionEngine {
     pub ptr: LLVMExecutionEngineRef,
 }
+impl_llvm_ref!(ExecutionEngine, LLVMExecutionEngineRef);
 
 impl ExecutionEngine {
     pub fn create_for_module(module: &Module) -> Result<ExecutionEngine, &'static str> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ macro_rules! c_str_to_str {
     }
 }
 
+#[macro_use]
+mod macros;
 mod context;
 mod types;
 mod builder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@ mod function;
 mod pass_manager;
 mod target;
 mod execution_engine;
+mod value;
 
+// TODO: This was to maintain compatiblity, we should remove this
 pub use context::*;
 pub use types::*;
 pub use builder::*;
@@ -30,6 +32,7 @@ pub use function::*;
 pub use pass_manager::*;
 pub use target::*;
 pub use execution_engine::*;
+pub use value::*;
 
 pub fn set_value_name(val: LLVMValueRef, name: &str) {
     let c_name = CString::new(name).unwrap();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,18 @@
+// TODO: This could be named better
+macro_rules! impl_llvm_ref {
+    ($dest: tt, $ref: ty) => {
+        impl From<$ref> for $dest {
+            fn from(ptr: $ref) -> Self {
+                $dest {
+                    ptr: ptr,
+                }
+            }
+        }
+
+        impl From<$dest> for $ref {
+            fn from(s: $dest) -> Self {
+                s.ptr
+            }
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -11,6 +11,7 @@ use super::*;
 pub struct Module {
     pub ptr: LLVMModuleRef
 }
+impl_llvm_ref!(Module, LLVMModuleRef);
 
 impl Module {
     pub fn dump(&self) {

--- a/src/pass_manager.rs
+++ b/src/pass_manager.rs
@@ -4,6 +4,7 @@ use llvm_sys::prelude::*;
 pub struct PassManager {
     pub ptr: LLVMPassManagerRef,
 }
+impl_llvm_ref!(PassManager, LLVMPassManagerRef);
 
 impl PassManager {
     pub fn new() -> PassManager {

--- a/src/target.rs
+++ b/src/target.rs
@@ -6,6 +6,7 @@ use super::*;
 pub struct Target {
     ptr: LLVMTargetRef,
 }
+impl_llvm_ref!(Target, LLVMTargetRef);
 
 impl Target {
     pub fn from_name(name: &str) -> Option<Target> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,11 +1,7 @@
 use llvm_sys::prelude::*;
-use llvm_sys::core as llvm;
+use llvm_sys::core::*;
 
-pub fn const_int(ty: LLVMTypeRef, val: u64, signed: bool) -> LLVMValueRef {
-    unsafe {
-        llvm::LLVMConstInt(ty, val, signed as i32)
-    }
-}
+use super::*;
 
 pub fn function_type(ret_ty: LLVMTypeRef,
                      mut param_types: Vec<LLVMTypeRef>,
@@ -23,3 +19,41 @@ pub fn pointer_type(ty: LLVMTypeRef, address_space: u32) -> LLVMTypeRef {
         llvm::LLVMPointerType(ty, address_space)
     }
 }
+
+pub trait Type: ContextType /* + GlobalType*/{}
+
+/// Represents a LLVM Context Type
+pub trait ContextType {
+    fn get_type_in_context(context: &Context) -> LLVMTypeRef;
+}
+
+macro_rules! impl_context_type {
+    ($t: ty, $to_type_in_context: ident) => {
+        impl ContextType for $t {
+            fn get_type_in_context(context: &Context) -> LLVMTypeRef {
+                unsafe {
+                    $to_type_in_context(context.ptr)
+                }
+            }
+        }
+    }
+}
+
+
+impl_context_type!(bool, LLVMInt1TypeInContext);
+// This might actually not be true, Not sure
+impl_context_type!(char, LLVMInt8TypeInContext);
+impl_context_type!(u8, LLVMInt8TypeInContext);
+impl_context_type!(u16, LLVMInt16TypeInContext);
+impl_context_type!(u32, LLVMInt32TypeInContext);
+impl_context_type!(u64, LLVMInt64TypeInContext);
+impl_context_type!(i8, LLVMInt8TypeInContext);
+impl_context_type!(i16, LLVMInt16TypeInContext);
+impl_context_type!(i32, LLVMInt32TypeInContext);
+impl_context_type!(i64, LLVMInt64TypeInContext);
+impl_context_type!(f32, LLVMFloatTypeInContext);
+impl_context_type!(f64, LLVMDoubleTypeInContext);
+//TODO: Function Types
+//TODO: Structure Types
+//TODO: Sequential Types
+//TODO: Other Types

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,7 +2,12 @@ use llvm_sys::prelude::*;
 use llvm_sys::core as llvm;
 use super::*;
 
-/// Represnts a type that can be inserted as a const in a context
+pub struct Value {
+    ptr: LLVMValueRef,
+}
+impl_llvm_ref!(Value, LLVMValueRef);
+
+/// Represents a type that can be inserted as a const in a context
 pub trait IntoConstValue: ContextType {
     fn gen_const(self, context: &Context) -> LLVMValueRef;
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,52 @@
+use llvm_sys::prelude::*;
+use llvm_sys::core as llvm;
+use super::*;
+
+/// Represnts a type that can be inserted as a const in a context
+pub trait IntoConstValue: ContextType {
+    fn gen_const(self, context: &Context) -> LLVMValueRef;
+}
+
+macro_rules! impl_const_value {
+    // TODO: this `tt` should be a `ty`, for some reason this causes
+    // the macro to fail, we should file a bug report
+    (UINT: $t: tt) => {
+        impl IntoConstValue for $t {
+            fn gen_const(self, context: &Context) -> LLVMValueRef {
+                unsafe {
+                    llvm::LLVMConstInt($t::get_type_in_context(context), self.into(), 0)
+                }
+            }
+        }
+    };
+    (INT: $t: tt) => {
+        impl IntoConstValue for $t {
+            fn gen_const(self, context: &Context) -> LLVMValueRef {
+                unsafe {
+                    llvm::LLVMConstInt($t::get_type_in_context(context), self as u64, 1)
+                }
+            }
+        }
+    };
+    (FLOAT: $t: tt) => {
+        impl IntoConstValue for $t {
+            fn gen_const(self, context: &Context) -> LLVMValueRef {
+                unsafe {
+                    llvm::LLVMConstReal($t::get_type_in_context(context), self.into())
+                }
+            }
+        }
+    }
+}
+
+//TODO: Missing OfString and OfStringAndSize variants
+impl_const_value!(FLOAT: f64);
+impl_const_value!(FLOAT: f32);
+impl_const_value!(UINT: u8);
+impl_const_value!(UINT: u16);
+impl_const_value!(UINT: u32);
+impl_const_value!(UINT: u64);
+impl_const_value!(INT: i8);
+impl_const_value!(INT: i16);
+impl_const_value!(INT: i32);
+impl_const_value!(INT: i64);


### PR DESCRIPTION
Hi,

This PR adds adds automatic type inference for constant values in a context.
It also adds a macro that automaticaly implements From<> for a llvm reference and a type