### PR TITLE
Impl Debug for all public types.

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -29,6 +29,7 @@ macro_rules! build_op {
     }
 }
 
+#[derive(Debug)]
 pub struct Builder {
     pub ptr: LLVMBuilderRef
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,6 +7,7 @@ use value::IntoConstValue;
 
 // LLVM Wrappers
 
+#[derive(Debug)]
 pub struct Context {
     pub ptr: LLVMContextRef
 }

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -2,6 +2,7 @@ use llvm_sys::execution_engine::*;
 use super::*;
 use std::mem;
 
+#[derive(Debug)]
 pub struct ExecutionEngine {
     pub ptr: LLVMExecutionEngineRef,
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,6 +1,7 @@
 use llvm_sys::prelude::*;
 use llvm_sys::core as llvm;
 
+#[derive(Debug)]
 pub struct Function {
     pub ptr: LLVMValueRef,
 }
@@ -36,6 +37,7 @@ impl Function {
 }
 
 
+#[derive(Debug)]
 pub struct FunctionParamIter {
     arg: LLVMValueRef,
     first: bool,

--- a/src/module.rs
+++ b/src/module.rs
@@ -8,6 +8,7 @@ use llvm_sys::core as llvm;
 use super::*;
 
 // No `Drop` impl is needed as this is disposed of when the associated context is disposed
+#[derive(Debug)]
 pub struct Module {
     pub ptr: LLVMModuleRef
 }

--- a/src/pass_manager.rs
+++ b/src/pass_manager.rs
@@ -1,6 +1,7 @@
 use llvm_sys::core as llvm;
 use llvm_sys::prelude::*;
 
+#[derive(Debug)]
 pub struct PassManager {
     pub ptr: LLVMPassManagerRef,
 }

--- a/src/target.rs
+++ b/src/target.rs
@@ -3,6 +3,7 @@ use llvm_sys::target_machine::*;
 use llvm_sys::target::*;
 use super::*;
 
+#[derive(Debug)]
 pub struct Target {
     ptr: LLVMTargetRef,
 }
@@ -34,6 +35,7 @@ impl Target {
     }
 }
 
+#[derive(Debug)]
 pub struct TargetMachine {
     ptr: LLVMTargetMachineRef,
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,6 +2,7 @@ use llvm_sys::prelude::*;
 use llvm_sys::core as llvm;
 use super::*;
 
+#[derive(Debug)]
 pub struct Value {
     ptr: LLVMValueRef,
 }


### PR DESCRIPTION
The rust [documentation] for `fmt::Debug` states that libraries should ensure that all public types implement the `Debug` trait:

> `fmt::Debug` implementations should be implemented for **all** public types. Output will typically represent the internal state as faithfully as possible. The purpose of the `Debug` trait is to facilitate debugging Rust code. In most cases, using `#[derive(Debug)]` is sufficient and recommended.

[documentation]: https://doc.rust-lang.org/std/fmt/#fmtdisplay-vs-fmtdebug

This PR adds the necessary code to follow this spec, allowing users of this crate to `#[derive(Debug)]` on their own structs that utilize llvm types and format them using `{:?}`.