### PR TITLE
using reference of `Function` in build_call

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -188,7 +188,7 @@ impl Builder {
         }
     }
 
-    pub fn build_call(&mut self, func: Function, mut args: Vec<LLVMValueRef>,
+    pub fn build_call(&mut self, func: &Function, mut args: Vec<LLVMValueRef>,
                       name: &str) -> LLVMValueRef {
         let c_name = CString::new(name).unwrap();
         unsafe {


### PR DESCRIPTION
using reference is batter, because `Function` can't clone and in some situation we need to keep a handle for that function object.